### PR TITLE
Fixed comment under "Installation".

### DIFF
--- a/frame-tag.el
+++ b/frame-tag.el
@@ -35,7 +35,7 @@
 ;;; Installation
 
 ;; (add-to-list 'load-path "/path/to/frame-tag")
-;; (require 'frame-numbering)
+;; (require 'frame-tag)
 ;; (frame-tag-mode 1)
 
 ;;; Code:


### PR DESCRIPTION
It looks like this package may have once been name ``frame-numbering'', but is now called ``frame-tag''.